### PR TITLE
Common mark nt

### DIFF
--- a/lib/protos/markdown.rb
+++ b/lib/protos/markdown.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "protos"
-require "markly"
+require "commonmarker"
 require "rouge"
 require "delegate"
 
@@ -37,7 +37,7 @@ module Protos
       plain(node.string_content)
     end
 
-    def visit_header(node)
+    def visit_heading(node)
       case node.header_level
       in 1 then h1 { visit_children(node) }
       in 2 then h2 { visit_children(node) }
@@ -80,12 +80,13 @@ module Protos
 
     def visit_list(node)
       case node.list_type
-      when :ordered_list then ol { visit_children(node) }
-      when :bullet_list then ul { visit_children(node) }
+      when :ordered then ol { visit_children(node) }
+      when :bullet then ul { visit_children(node) }
+      else raise ArgumentError, "Unknown list type: #{node.list_type}"
       end
     end
 
-    def visit_list_item(node)
+    def visit_item(node)
       li { visit_children(node) }
     end
 
@@ -105,11 +106,11 @@ module Protos
       end
     end
 
-    def visit_hrule(_node)
+    def visit_thematic_break(_node)
       hr
     end
 
-    def visit_blockquote(node)
+    def visit_block_quote(node)
       blockquote { visit_children(node) }
     end
 
@@ -119,10 +120,10 @@ module Protos
       raw safe(node.string_content)
     end
 
-    def visit_inline_html(node)
+    def visit_html_inline(node)
       return if @sanitize
 
-      raw safe(node.string_content)
+      raw safe(node.to_html(options: { render: { unsafe: true } }))
     end
 
     private

--- a/lib/protos/markdown.rb
+++ b/lib/protos/markdown.rb
@@ -131,6 +131,10 @@ module Protos
       nil
     end
 
+    def visit_escaped(node)
+      plain(node.first_child&.string_content)
+    end
+
     private
 
     def root

--- a/lib/protos/markdown.rb
+++ b/lib/protos/markdown.rb
@@ -12,6 +12,7 @@ module Protos
   class Markdown < ::Protos::Component # rubocop:disable Metrics/ClassLength
     param :content, reader: false
     option :sanitize, default: -> { true }, reader: false
+    option :markdown_options, default: -> { {} }, reader: false
 
     def view_template
       return unless root
@@ -129,7 +130,7 @@ module Protos
     private
 
     def root
-      AST.parse(@content)
+      AST.parse(@content, markdown_options: @markdown_options)
     end
 
     def formatter

--- a/lib/protos/markdown.rb
+++ b/lib/protos/markdown.rb
@@ -127,6 +127,10 @@ module Protos
       raw safe(node.to_html(options: { render: { unsafe: true } }))
     end
 
+    def visit_html_block(_node)
+      nil
+    end
+
     private
 
     def root

--- a/lib/protos/markdown.rb
+++ b/lib/protos/markdown.rb
@@ -14,6 +14,26 @@ module Protos
     option :sanitize, default: -> { true }, reader: false
     option :markdown_options, default: -> { {} }, reader: false
 
+    Heading = Data.define(:node) do
+      def id
+        text.downcase.gsub(/[^a-z0-9]+/, "-").chomp("-")
+      end
+
+      def text
+        begin
+          node.string_content
+        rescue TypeError
+          node.first_child&.string_content || ""
+        end
+      rescue TypeError
+        ""
+      end
+
+      def header_level
+        node.header_level
+      end
+    end
+
     def view_template
       return unless root
 
@@ -39,13 +59,15 @@ module Protos
     end
 
     def visit_heading(node)
-      case node.header_level
-      in 1 then h1 { visit_children(node) }
-      in 2 then h2 { visit_children(node) }
-      in 3 then h3 { visit_children(node) }
-      in 4 then h4 { visit_children(node) }
-      in 5 then h5 { visit_children(node) }
-      in 6 then h6 { visit_children(node) }
+      heading = Heading.new(node)
+
+      case heading.header_level
+      in 1 then h1(id: heading.id) { visit_children(node) }
+      in 2 then h2(id: heading.id) { visit_children(node) }
+      in 3 then h3(id: heading.id) { visit_children(node) }
+      in 4 then h4(id: heading.id) { visit_children(node) }
+      in 5 then h5(id: heading.id) { visit_children(node) }
+      in 6 then h6(id: heading.id) { visit_children(node) }
       end
     end
 

--- a/lib/protos/markdown.rb
+++ b/lib/protos/markdown.rb
@@ -20,13 +20,13 @@ module Protos
       end
 
       def text
-        begin
-          node.string_content
+        buffer = +""
+        node.walk do |node|
+          buffer << node.string_content
         rescue TypeError
-          node.first_child&.string_content || ""
+          # Ignore non-text nodes
         end
-      rescue TypeError
-        ""
+        buffer
       end
 
       def header_level

--- a/lib/protos/markdown/ast.rb
+++ b/lib/protos/markdown/ast.rb
@@ -19,12 +19,13 @@ module Protos
 
       def self.parse(content, **kwargs)
         options = {
-          flags: Markly::GITHUB_PRE_LANG,
-          extensions: [:table]
-        }.merge(kwargs)
+          render: { gfm_quirks: true },
+          extension: { table: true },
+          **kwargs
+        }
 
-        Markly
-          .parse(content, **options)
+        Commonmarker
+          .parse(content, options:)
           .then { |node| new(Node.new(node)) }
       end
 

--- a/lib/protos/markdown/ast.rb
+++ b/lib/protos/markdown/ast.rb
@@ -17,11 +17,11 @@ module Protos
         end
       end
 
-      def self.parse(content, **kwargs)
+      def self.parse(content, markdown_options: {})
         options = {
           render: { gfm_quirks: true },
           extension: { table: true },
-          **kwargs
+          **markdown_options
         }
 
         Commonmarker

--- a/lib/protos/markdown/table.rb
+++ b/lib/protos/markdown/table.rb
@@ -3,7 +3,7 @@
 module Protos
   class Markdown
     class Table < Protos::Table
-      option :inside_header, default: -> { false }, reader: false
+      option :inside_header, default: -> { true }, reader: false
 
       def visit_table(node)
         visit_children(node)
@@ -30,11 +30,11 @@ module Protos
       end
 
       def visit_table_row(node)
-        @inside_header = false
-
         row do
           visit_children(node)
         end
+
+        @inside_header = false
       end
 
       def visit_code(node)

--- a/protos-markdown.gemspec
+++ b/protos-markdown.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "markly", "~> 0.9"
+  spec.add_dependency "commonmarker", "~> 2.3"
   spec.add_dependency "protos", "~> 1"
   spec.add_dependency "rouge", "~> 4"
 

--- a/protos-markdown.gemspec
+++ b/protos-markdown.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "protos-markdown"
-  spec.version = "1.0.0"
+  spec.version = "1.1.0"
   spec.authors = ["Nolan Tait"]
   spec.email = ["nolanjtait@gmail.com"]
 

--- a/spec/protos/custom_component_spec.rb
+++ b/spec/protos/custom_component_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Custom components" do
   before do
     stub_const(
       "CustomMarkdown", Class.new(Protos::Markdown) do
-        def h1 = super(class: css[:title])
-        def ul = super(class: "ml-4 pt-2")
+        def h1(**options) = super(class: css[:title], **options)
+        def ul(**options) = super(class: "ml-4 pt-2", **options)
 
         private
 
@@ -32,7 +32,7 @@ RSpec.describe "Custom components" do
     output = CustomMarkdown.new(input).call
 
     expected_output = <<~HTML
-      <h1 class="font-bold text-xl">Hello World</h1>
+      <h1 class="font-bold text-xl" id="hello-world">Hello World</h1>
       <ul class="ml-4 pt-2">
         <li>A</li>
         <li>B</li>

--- a/spec/protos/markdown_spec.rb
+++ b/spec/protos/markdown_spec.rb
@@ -57,12 +57,12 @@ RSpec.describe Protos::Markdown, type: :view do
       ###### 6
     MD
 
-    expect(page).to have_css "h1", text: "1"
-    expect(page).to have_css "h2", text: "2"
-    expect(page).to have_css "h3", text: "3"
-    expect(page).to have_css "h4", text: "4"
-    expect(page).to have_css "h5", text: "5"
-    expect(page).to have_css "h6", text: "6"
+    expect(page).to have_css "h1", text: "1", id: "1"
+    expect(page).to have_css "h2", text: "2", id: "2"
+    expect(page).to have_css "h3", text: "3", id: "3"
+    expect(page).to have_css "h4", text: "4", id: "4"
+    expect(page).to have_css "h5", text: "5", id: "5"
+    expect(page).to have_css "h6", text: "6", id: "6"
   end
 
   it "supports ordered lists" do

--- a/spec/protos/markdown_spec.rb
+++ b/spec/protos/markdown_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe Protos::Markdown, type: :view do
     render Protos::Markdown.new(content, sanitize: false)
   end
 
+  it "handles html blocks" do
+    render_markdown <<~MD
+      <!-- This is a comment -->
+    MD
+
+    expect(page).not_to have_content "<!-- This is a comment -->"
+  end
+
   it "supports tables" do
     render_markdown <<~MD
       |**Entity ID**|`Health`|

--- a/spec/protos/markdown_spec.rb
+++ b/spec/protos/markdown_spec.rb
@@ -47,6 +47,15 @@ RSpec.describe Protos::Markdown, type: :view do
     expect(page).to have_css "div", text: "Hello"
   end
 
+  it "supports headings with links" do
+    render_markdown <<~MD
+      # [Introduction](/something)
+    MD
+
+    expect(page).to have_css "h1", id: "introduction"
+    expect(page).to have_css "h1 a", text: "Introduction"
+  end
+
   it "supports multiple headings" do
     render_markdown <<~MD
       # 1

--- a/spec/protos/markdown_spec.rb
+++ b/spec/protos/markdown_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe Protos::Markdown, type: :view do
 
   it "supports tables" do
     render_markdown <<~MD
-      |**Entity ID**| `Health` |
-      |:-----------:|:------:|
-      | 1           | 100.0  |
-      | 3           | 40.0   |
+      |**Entity ID**|`Health`|
+      |-------------|--------|
+      | 1           |100.0   |
+      | 3           |40.0    |
     MD
 
     expect(page).to have_css "table"
@@ -22,7 +22,7 @@ RSpec.describe Protos::Markdown, type: :view do
     expect(page).to have_css "td", text: "100.0"
     expect(page).to have_css "td", text: "3"
     expect(page).to have_css "td", text: "40.0"
-    expect(page).to have_css "tr", count: 2
+    expect(page).to have_css "tr", count: 3
     expect(page).to have_css "code", text: "Health"
     expect(page).to have_css "strong", text: "Entity ID"
   end

--- a/spec/protos/markdown_spec.rb
+++ b/spec/protos/markdown_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Protos::Markdown, type: :view do
     render Protos::Markdown.new(content, sanitize: false)
   end
 
+  it "handles escaped characters" do
+    render_markdown "Hello \\*World\\*"
+
+    expect(page).to have_css "p", text: "Hello *World*"
+  end
+
   it "handles html blocks" do
     render_markdown <<~MD
       <!-- This is a comment -->


### PR DESCRIPTION
- Switches to CommonMark instead of Markly which has more active support (Markly broke in gcc15)
- Adds support for heading levels and ids by default